### PR TITLE
fix invalid "defaultLocale" is not valid BCP47 formatted locale string

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -103,6 +103,6 @@ class Translator implements TranslatorInterface
 
     protected function getDefaultLocale(): string
     {
-        return $this->defaultLocale ?? \Locale::getDefault();
+        return $this->defaultLocale ?? 'en';
     }
 }


### PR DESCRIPTION
if "defaultLocale" is not set manually, then when receiving from the system, the return invalid BCP47 format

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 
